### PR TITLE
Fix game mode datatypes

### DIFF
--- a/zm/ram.yml
+++ b/zm/ram.yml
@@ -712,23 +712,23 @@
 -
   desc: Game mode
   label: GameMode
-  type: u16
+  type: i16
   addr: 0x3000C70
   enum: GameMode
 -
   desc: Sub-game mode 1
   label: SubGameMode1
-  type: u16
+  type: i16
   addr: 0x3000C72
 -
   desc: Sub-game mode 2
   label: SubGameMode2
-  type: u8
+  type: i8
   addr: 0x3000C74
 -
   desc: Sub-game mode 3
   label: SubGameMode3
-  type: u8
+  type: i8
   addr: 0x3000C75
 -
   desc: Cleared every frame


### PR DESCRIPTION
Found this during the decompile; game modes seem to be signed.